### PR TITLE
Fixing Folders with Apostrophes

### DIFF
--- a/gallery/__init__.py
+++ b/gallery/__init__.py
@@ -196,7 +196,7 @@ def api_mkdir(internal=False, parent_id=None, dir_name=None, owner=None,
     # at this point path is something like
     # gallery-data/root
     file_path = os.path.join(path, request.form.get('dir_name'))
-    _, count = re.subn(r'[^a-zA-Z0-9 \/\-\_]', '', file_path)
+    _, count = re.subn(r'[^a-zA-Z0-9 \/\-\_\']', '', file_path)
     if not file_path.startswith("/gallery-data/root") or count != 0:
         return "invalid path" + file_path, 400
 

--- a/gallery/__init__.py
+++ b/gallery/__init__.py
@@ -197,8 +197,10 @@ def api_mkdir(internal=False, parent_id=None, dir_name=None, owner=None,
     # gallery-data/root
     file_path = os.path.join(path, request.form.get('dir_name'))
     _, count = re.subn(r'[^a-zA-Z0-9 \/\-\_\']', '', file_path)
-    if not file_path.startswith("/gallery-data/root") or count != 0:
-        return "invalid path" + file_path, 400
+    if not file_path.startswith("/gallery-data/root"):
+        return "invalid path: " + file_path, 400
+    if count != 0:
+        return "invalid directory name: " + file_path, 400
 
     # mkdir -p that shit
     if not os.path.exists(file_path):


### PR DESCRIPTION
So this fix in the Regex fixes `'` characters in creating folders. However I noticed that the reason it works when you rename folders, is that there is [no character filtering](https://github.com/liam-middlebrook/gallery/blob/develop/gallery/__init__.py#L467). It currently blocks all directory names not covered by this regex.

This shows that the regex handles now:
https://regexr.com/3gp58

If we want to support more characters we can just add them to the regex/remove the regex check/add the regex check to renaming

Fixes #24 